### PR TITLE
Linting Corrections for Active SSHD Config

### DIFF
--- a/lib/inspec/resources/ssh_config.rb
+++ b/lib/inspec/resources/ssh_config.rb
@@ -1,14 +1,14 @@
 # copyright: 2015, Vulcano Security GmbH
 
-require 'inspec/utils/simpleconfig'
-require 'inspec/utils/file_reader'
+require "inspec/utils/simpleconfig"
+require "inspec/utils/file_reader"
 
 module Inspec::Resources
   class SshConfig < Inspec.resource(1)
-    name 'ssh_config'
-    supports platform: 'unix'
-    supports platform: 'windows'
-    desc 'Use the `ssh_config` InSpec audit resource to test OpenSSH client configuration data located at `/etc/ssh/ssh_config` on Linux and Unix platforms.'
+    name "ssh_config"
+    supports platform: "unix"
+    supports platform: "windows"
+    desc "Use the `ssh_config` InSpec audit resource to test OpenSSH client configuration data located at `/etc/ssh/ssh_config` on Linux and Unix platforms."
     example <<~EXAMPLE
       describe ssh_config do
         its('cipher') { should contain '3des' }
@@ -20,8 +20,8 @@ module Inspec::Resources
     include FileReader
 
     def initialize(conf_path = nil, type = nil)
-      @conf_path = conf_path || ssh_config_file('ssh_config')
-      typename = (@conf_path.include?('sshd') ? 'Server' : 'Client')
+      @conf_path = conf_path || ssh_config_file("ssh_config")
+      typename = (@conf_path.include?("sshd") ? "Server" : "Client")
       @type = type || "SSH #{typename} configuration #{conf_path}"
       read_content
     end
@@ -51,11 +51,11 @@ module Inspec::Resources
     end
 
     def to_s
-      'SSH Configuration'
+      "SSH Configuration"
     end
 
     def resource_id
-      @conf_path || 'SSH Configuration'
+      @conf_path || "SSH Configuration"
     end
 
     private
@@ -81,7 +81,7 @@ module Inspec::Resources
 
     def ssh_config_file(type)
       if inspec.os.windows?
-        programdata = inspec.os_env('programdata').content
+        programdata = inspec.os_env("programdata").content
         return "#{programdata}\\ssh\\#{type}"
       end
 
@@ -90,10 +90,10 @@ module Inspec::Resources
   end
 
   class SshdConfig < SshConfig
-    name 'sshd_config'
-    supports platform: 'unix'
-    supports platform: 'windows'
-    desc 'Use the sshd_config InSpec audit resource to test configuration data for the Open SSH daemon located at /etc/ssh/sshd_config on Linux and UNIX platforms. sshd---the Open SSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command execution, and data exchanges.'
+    name "sshd_config"
+    supports platform: "unix"
+    supports platform: "windows"
+    desc "Use the sshd_config InSpec audit resource to test configuration data for the Open SSH daemon located at /etc/ssh/sshd_config on Linux and UNIX platforms. sshd---the Open SSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command execution, and data exchanges."
     example <<~EXAMPLE
       describe sshd_config do
         its('Protocol') { should eq '2' }
@@ -101,18 +101,18 @@ module Inspec::Resources
     EXAMPLE
 
     def initialize(path = nil)
-      super(path || ssh_config_file('sshd_config'))
+      super(path || ssh_config_file("sshd_config"))
     end
 
     def to_s
-      'SSHD Configuration'
+      "SSHD Configuration"
     end
 
     private
 
     def ssh_config_file(type)
       if inspec.os.windows?
-        programdata = inspec.os_env('programdata').content
+        programdata = inspec.os_env("programdata").content
         return "#{programdata}\\ssh\\#{type}"
       end
 
@@ -121,10 +121,10 @@ module Inspec::Resources
   end
 
   class SshdActiveConfig < SshdConfig
-    name 'sshd_active_config'
-    supports platform: 'unix'
-    supports platform: 'windows'
-    desc 'Use the sshd_active_config InSpec audit resource to test configuration data for the Open SSH daemon located at /etc/ssh/sshd_config on Linux and UNIX platforms. sshd---the Open SSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command execution, and data exchanges.'
+    name "sshd_active_config"
+    supports platform: "unix"
+    supports platform: "windows"
+    desc "Use the sshd_active_config InSpec audit resource to test configuration data for the Open SSH daemon located at /etc/ssh/sshd_config on Linux and UNIX platforms. sshd---the Open SSH daemon---listens on dedicated ports, starts a daemon for each incoming connection, and then handles encryption, authentication, key exchanges, command execution, and data exchanges."
     example <<~EXAMPLE
       describe sshd_active_config do
         its('Protocol') { should eq '2' }
@@ -146,7 +146,7 @@ module Inspec::Resources
 
     def ssh_config_file(type)
       if inspec.os.windows?
-        programdata = inspec.os_env('programdata').content
+        programdata = inspec.os_env("programdata").content
         return "#{programdata}\\ssh\\#{type}"
       end
 
@@ -165,13 +165,13 @@ module Inspec::Resources
         EOH
         sshd_path_result = inspec.powershell(script).stdout.strip
         sshd_path = "\"#{sshd_path_result}\""
-        if !sshd_path_result.empty? && sshd_path_result != 'sshd.exe not found'
+        if !sshd_path_result.empty? && sshd_path_result != "sshd.exe not found"
           command_output = inspec.command("sudo #{sshd_path} -dd 2>&1").stdout
           dynamic_path =
             command_output
-            .lines
-            .find { |line| line.include?('filename') }
-              &.split('filename')
+              .lines
+              .find { |line| line.include?("filename") }
+              &.split("filename")
               &.last
               &.strip
           env_var_name = dynamic_path.match(/__(.*?)__/)[1]
@@ -183,31 +183,31 @@ module Inspec::Resources
               )
           end
         else
-          Inspec::Log.error('sshd.exe not found using PowerShell script block.')
+          Inspec::Log.error("sshd.exe not found using PowerShell script block.")
           return nil
         end
       elsif inspec.os.unix?
-        sshd_path = '/usr/sbin/sshd'
+        sshd_path = "/usr/sbin/sshd"
         command_output = inspec.command("sudo #{sshd_path} -dd 2>&1").stdout
         dynamic_path =
           command_output
-          .lines
-          .find { |line| line.include?('filename') }
-            &.split('filename')
+            .lines
+            .find { |line| line.include?("filename") }
+            &.split("filename")
             &.last
             &.strip
       else
         Inspec::Log.error(
-          'Unable to determine sshd configuration path on Windows using -T flag.'
+          "Unable to determine sshd configuration path on Windows using -T flag."
         )
         return nil
       end
 
       if dynamic_path.nil? || dynamic_path.empty?
         Inspec::Log.warn(
-          'No active SSHD configuration found. Using default configuration.'
+          "No active SSHD configuration found. Using default configuration."
         )
-        return ssh_config_file('sshd_config')
+        return ssh_config_file("sshd_config")
       end
       dynamic_path
     end

--- a/test/unit/resources/ssh_conf_test.rb
+++ b/test/unit/resources/ssh_conf_test.rb
@@ -1,63 +1,63 @@
-require 'helper'
-require 'inspec/resource'
-require 'inspec/resources/ssh_config'
+require "helper"
+require "inspec/resource"
+require "inspec/resources/ssh_config"
 
-describe 'Inspec::Resources::SshConfig' do
-  describe 'ssh_config' do
-    it 'check ssh config parsing' do
-      resource = load_resource('ssh_config')
-      _(resource.Host).must_equal '*'
+describe "Inspec::Resources::SshConfig" do
+  describe "ssh_config" do
+    it "check ssh config parsing" do
+      resource = load_resource("ssh_config")
+      _(resource.Host).must_equal "*"
       _(resource.Tunnel).must_be_nil
-      _(resource.SendEnv).must_equal 'LANG LC_*'
-      _(resource.HashKnownHosts).must_equal 'yes'
+      _(resource.SendEnv).must_equal "LANG LC_*"
+      _(resource.HashKnownHosts).must_equal "yes"
     end
 
-    it 'is case insensitive' do
-      resource = load_resource('ssh_config')
-      _(resource.gssapiauthentication).must_equal 'no'
-      _(resource.GSSAPIAuthentication).must_equal 'no'
+    it "is case insensitive" do
+      resource = load_resource("ssh_config")
+      _(resource.gssapiauthentication).must_equal "no"
+      _(resource.GSSAPIAuthentication).must_equal "no"
     end
 
-    it 'uses the first value encountered' do
-      resource = load_resource('ssh_config')
-      _(resource.HostBasedAuthentication).must_equal 'yes'
+    it "uses the first value encountered" do
+      resource = load_resource("ssh_config")
+      _(resource.HostBasedAuthentication).must_equal "yes"
     end
   end
 
-  describe 'sshd_config' do
-    it 'check protocol version' do
-      resource = load_resource('sshd_config')
-      _(resource.Port).must_equal '22'
-      _(resource.UsePAM).must_equal 'yes'
+  describe "sshd_config" do
+    it "check protocol version" do
+      resource = load_resource("sshd_config")
+      _(resource.Port).must_equal "22"
+      _(resource.UsePAM).must_equal "yes"
       _(resource.ListenAddress).must_be_nil
       _(resource.HostKey).must_equal [
-        '/etc/ssh/ssh_host_rsa_key',
-        '/etc/ssh/ssh_host_dsa_key',
-        '/etc/ssh/ssh_host_ecdsa_key'
+        "/etc/ssh/ssh_host_rsa_key",
+        "/etc/ssh/ssh_host_dsa_key",
+        "/etc/ssh/ssh_host_ecdsa_key",
       ]
     end
 
-    it 'check bad path' do
-      resource = load_resource('sshd_config', '/etc/ssh/sshd_config_does_not_exist')
+    it "check bad path" do
+      resource = load_resource("sshd_config", "/etc/ssh/sshd_config_does_not_exist")
       _(resource.resource_exception_message).must_equal "Can't find file: /etc/ssh/sshd_config_does_not_exist"
     end
 
-    it 'check cannot read' do
-      resource = load_resource('sshd_config', '/etc/ssh/sshd_config_empty')
-      _(resource.resource_exception_message).must_equal 'File is empty: /etc/ssh/sshd_config_empty'
+    it "check cannot read" do
+      resource = load_resource("sshd_config", "/etc/ssh/sshd_config_empty")
+      _(resource.resource_exception_message).must_equal "File is empty: /etc/ssh/sshd_config_empty"
     end
   end
 
-  describe 'sshd_active_config' do
-    it 'check protocol version' do
-      resource = load_resource('sshd_active_config')
-      _(resource.Port).must_equal '22'
-      _(resource.UsePAM).must_equal 'yes'
+  describe "sshd_active_config" do
+    it "check protocol version" do
+      resource = load_resource("sshd_active_config")
+      _(resource.Port).must_equal "22"
+      _(resource.UsePAM).must_equal "yes"
       _(resource.ListenAddress).must_be_nil
       _(resource.HostKey).must_equal [
-        '/etc/ssh/ssh_host_rsa_key',
-        '/etc/ssh/ssh_host_dsa_key',
-        '/etc/ssh/ssh_host_ecdsa_key'
+        "/etc/ssh/ssh_host_rsa_key",
+        "/etc/ssh/ssh_host_dsa_key",
+        "/etc/ssh/ssh_host_ecdsa_key",
       ]
     end
   end


### PR DESCRIPTION
Ran `bundle exec chefstyle -a` using v2.2.3 of chefstyle. Quoting and indentation changes. After merging this PR to your branch, your PR against core should have very few/no quoting changes against core.

These (pedantic) changes are required by the private linter pipeline on InSpec Core, which just runs chefstyle with some exceptions. 