### PR TITLE
Virtualization container update

### DIFF
--- a/docs-chef-io/content/inspec/resources/virtualization.md
+++ b/docs-chef-io/content/inspec/resources/virtualization.md
@@ -76,23 +76,55 @@ This helper returns, if any of the supported virtualization platforms was detect
 
 If no virtualization platform is detected, this will return `true`. For unsupported virtualization platforms this can result in false positives.
 
+### virtualization.container_system? Helper
+
+This helper returns `true` when a supported container platform was detected and the machine under test is a guest.
+
+The helper returns `true` for these detected systems: `container-other`, `docker`, `kubepods`, `linux-vserver`, `lxc`, `lxc-libvirt`, `openvz`, `podman`, `pouch`, `proot`, `rkt`, `systemd-nspawn`, and `wsl`.
+
+This helper doesn't return `true` for `lxd` because LXD guests can be containers or virtual machines.
+
 ### virtualization.system names
 
 The resource supports the following virtualization platforms:
 
 On Linux machines:
 
+- `acrn` (`guest` role only)
+- `amazon` (`guest` role only)
+- `apple` (`guest` role only)
+- `bochs` (`guest` role only)
+- `bhyve` (`guest` role only)
+- `container-other` (`guest` role only)
 - `docker` (`guest` role only)
+- `google` (`guest` role only)
 - `hyper-v` (`guest` role only)
 - `kvm`
-- `linux vserver`
+- `linux-vserver`
 - `lxc` / `lxd`
+- `lxc-libvirt` (`guest` role only)
+- `microsoft` (`guest` role only)
 - `openstack` (`host` role only)
 - `openvz`
+- `oracle` (`guest` role only)
 - `parallels` (`guest` role only)
+- `podman` (`guest` role only)
+- `pouch` (`guest` role only)
+- `powervm` (`guest` role only)
+- `proot` (`guest` role only)
+- `qemu` (`guest` role only)
+- `qnx` (`guest` role only)
+- `rkt` (`guest` role only)
+- `sre` (`guest` role only)
+- `systemd-nspawn` (`guest` role only)
+- `uml` (`guest` role only)
+- `vbox`
 - `virtualbox`
+- `vm-other` (`guest` role only)
 - `vmware` (`guest` role only)
+- `wsl` (`guest` role only)
 - `xen`
+- `zvm` (`guest` role only)
 
 On Windows machines (`guest` role only)
 

--- a/lib/inspec/resources/virtualization.rb
+++ b/lib/inspec/resources/virtualization.rb
@@ -24,6 +24,22 @@ module Inspec::Resources
       end
     EXAMPLE
 
+    CONTAINER_SYSTEMS = %w{
+      container-other
+      docker
+      kubepods
+      linux-vserver
+      lxc
+      lxc-libvirt
+      openvz
+      podman
+      pouch
+      proot
+      rkt
+      systemd-nspawn
+      wsl
+    }.freeze
+
     def initialize
       # TODO: no need for hashie here... in fact, no reason for a hash at all
       @virtualization_data = Hashie::Mash.new
@@ -52,6 +68,10 @@ module Inspec::Resources
 
     def physical_system?
       @virtualization_data[:physical]
+    end
+
+    def container_system?
+      @virtualization_data[:role] == "guest" && CONTAINER_SYSTEMS.include?(@virtualization_data[:system])
     end
 
     def params
@@ -297,6 +317,20 @@ module Inspec::Resources
       true
     end
 
+    # Detect virtualization via systemd-detect-virt
+    def detect_systemd_virt
+      cmd = inspec.command("systemd-detect-virt")
+      return false unless cmd.exist?
+      return false unless cmd.exit_status == 0
+
+      detected = cmd.stdout.to_s.strip
+      return false if detected.empty?
+
+      @virtualization_data[:system] = detected
+      @virtualization_data[:role] = "guest"
+      true
+    end
+
     def collect_data_linux
       # This avoids doing multiple detections in a single test
       return unless @virtualization_data.empty?
@@ -316,6 +350,7 @@ module Inspec::Resources
       return if detect_parallels
       return if detect_vmware
       return if detect_hyperv
+      return if detect_systemd_virt
     end
 
     def windows_computer_system

--- a/test/unit/resources/virtualization_test.rb
+++ b/test/unit/resources/virtualization_test.rb
@@ -66,4 +66,30 @@ describe "Inspec::Resources::Virtualization" do
       end
     end
   end
+
+  describe "container_system?" do
+    def virtualization_resource(system, role)
+      resource = Inspec::Resources::Virtualization.allocate
+      resource.instance_variable_set(:@virtualization_data, Hashie::Mash.new(system: system, role: role))
+      resource
+    end
+
+    it "returns true for detected container guests" do
+      %w{container-other docker kubepods linux-vserver lxc lxc-libvirt openvz podman pouch proot rkt systemd-nspawn wsl}.each do |system|
+        _(virtualization_resource(system, "guest")).must_be :container_system?
+      end
+    end
+
+    it "returns false for detected container hosts" do
+      %w{lxc openvz}.each do |system|
+        _(virtualization_resource(system, "host")).wont_be :container_system?
+      end
+    end
+
+    it "returns false for virtual machine guests and ambiguous LXD guests" do
+      %w{acrn amazon apple bochs bhyve google hyper-v kvm lxd microsoft openstack oracle parallels powervm qemu qnx sre uml vbox virtualbox vm-other vmware xen zvm}.each do |system|
+        _(virtualization_resource(system, "guest")).wont_be :container_system?
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Adds container detection support to the `virtualization` resource.

This change introduces a `container_system?` helper so profiles can quickly check whether the target is running as a supported container guest, without manually comparing `virtualization.system` and `virtualization.role`.

It also adds `systemd-detect-virt` as a Linux fallback detector, allowing the resource to report additional virtualization/container systems that systemd already recognizes, such as `lxc-libvirt`, `systemd-nspawn`, `wsl`, `proot`, `pouch`, `qemu`, `amazon`, `oracle`, `microsoft`, and `vm-other`.

The documentation was updated to list the expanded `virtualization.system` values and describe the new `container_system?` helper. LXD is intentionally excluded from `container_system?` because an LXD guest may be either a container or a VM.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.